### PR TITLE
Add "compression" flag to use native CloudSQL export file compression

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	bucket            = app.Flag("bucket", "Google Cloud Storage bucket name").Required().String()
 	project           = app.Flag("project", "GCP project ID").Required().String()
 	instance          = app.Flag("instance", "Cloud SQL instance name, if not specified all within the project will be enumerated").String()
+	compression       = app.Flag("compression", "Enable compression for exported SQL files").Bool()
 	ensureIamBindings = app.Flag("ensure-iam-bindings", "Ensure that the Cloud SQL service account has the required IAM role binding to export and validate the backup").Bool()
 )
 
@@ -70,7 +71,15 @@ func main() {
 			}
 		}
 
-		err := cloudsql.ExportCloudSQLDatabase(ctx, sqlAdminSvc, databases, *project, string(instance), *bucket, time.Now().Format(time.RFC3339Nano))
+		var objectName string
+
+		if *compression {
+			objectName = time.Now().Format(time.RFC3339Nano) + ".sql.gz"
+		} else {
+			objectName = time.Now().Format(time.RFC3339Nano) + ".sql"
+		}
+
+		err := cloudsql.ExportCloudSQLDatabase(ctx, sqlAdminSvc, databases, *project, string(instance), *bucket, objectName)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/cloudsql/cloudsql.go
+++ b/pkg/cloudsql/cloudsql.go
@@ -126,7 +126,7 @@ func ExportCloudSQLDatabase(ctx context.Context, sqlAdminSvc *sqladmin.Service, 
 				FileType:  "SQL",
 				Kind:      "sql#exportContext",
 				Databases: []string{database},
-				Uri:       fmt.Sprintf("gs://%s/%s/%s/%s/%s.sql", bucketName, projectID, instanceID, database, objectName),
+				Uri:       fmt.Sprintf("gs://%s/%s/%s/%s/%s", bucketName, projectID, instanceID, database, objectName),
 			},
 		}
 


### PR DESCRIPTION
Added a 'compression' flag to enable native CloudSQL export file compression, significantly reducing file size by approximately 5 times.

<img width="1255" alt="Screenshot 2024-03-07 at 16 23 03" src="https://github.com/trufflesecurity/cloudsql-exporter/assets/1148153/b7af752f-6bd6-46a2-90b9-52dfb3034bf6">

https://cloud.google.com/sql/docs/postgres/import-export#data-compression