### PR TITLE
Add fileType options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Flags:
   --ensure-iam-bindings  Ensure that the Cloud SQL service account has the
                          required IAM role binding to export and validate the
                          backup
-  --fileType             Type of file to export (SQL, SQL_FILE_TYPE_UNSPECIFIED, BAK, CSV)
+  --fileType             Type of file to export (SQL, SQL_FILE_TYPE_UNSPECIFIED, BAK, CSV) [Default SQL]
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Exporting your database to a separate Google Cloud Storage bucket, preferrably i
 
 ```bash
 $ cloudsql-exporter --help
-usage: cloudsql-backup --bucket=BUCKET --project=PROJECT [<flags>]
+usage: cloudsql-exporter --bucket=BUCKET --project=PROJECT [<flags>]
 
 Export Cloud SQL databases to Google Cloud Storage
 
@@ -31,6 +31,7 @@ Flags:
   --ensure-iam-bindings  Ensure that the Cloud SQL service account has the
                          required IAM role binding to export and validate the
                          backup
+  --fileType             Type of file to export (SQL, SQL_FILE_TYPE_UNSPECIFIED, BAK, CSV)
 ```
 
 ## Installation

--- a/main.go
+++ b/main.go
@@ -17,13 +17,14 @@ import (
 )
 
 var (
-	app = kingpin.New("cloudsql-backup", "Export Cloud SQL databases to Google Cloud Storage")
+	app = kingpin.New("cloudsql-exporter", "Export Cloud SQL databases to Google Cloud Storage")
 
 	bucket            = app.Flag("bucket", "Google Cloud Storage bucket name").Required().String()
 	project           = app.Flag("project", "GCP project ID").Required().String()
 	instance          = app.Flag("instance", "Cloud SQL instance name, if not specified all within the project will be enumerated").String()
 	compression       = app.Flag("compression", "Enable compression for exported SQL files").Bool()
 	ensureIamBindings = app.Flag("ensure-iam-bindings", "Ensure that the Cloud SQL service account has the required IAM role binding to export and validate the backup").Bool()
+	fileType		  = app.Flag("fileType", "Type of file to export (SQL, SQL_FILE_TYPE_UNSPECIFIED, BAK, CSV)").String()
 )
 
 func main() {
@@ -79,7 +80,7 @@ func main() {
 			objectName = time.Now().Format(time.RFC3339Nano) + ".sql"
 		}
 
-		err := cloudsql.ExportCloudSQLDatabase(ctx, sqlAdminSvc, databases, *project, string(instance), *bucket, objectName)
+		err := cloudsql.ExportCloudSQLDatabase(ctx, sqlAdminSvc, databases, *project, string(instance), *bucket, objectName, *fileType)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ var (
 	instance          = app.Flag("instance", "Cloud SQL instance name, if not specified all within the project will be enumerated").String()
 	compression       = app.Flag("compression", "Enable compression for exported SQL files").Bool()
 	ensureIamBindings = app.Flag("ensure-iam-bindings", "Ensure that the Cloud SQL service account has the required IAM role binding to export and validate the backup").Bool()
-	fileType		  = app.Flag("fileType", "Type of file to export (SQL, SQL_FILE_TYPE_UNSPECIFIED, BAK, CSV) [Default SQL]").String()
+	fileType		  = app.Flag("fileType", "Type of file to export (SQL, SQL_FILE_TYPE_UNSPECIFIED, BAK, CSV) [Default SQL]").Default("SQL").String()
 )
 
 func main() {
@@ -73,18 +73,13 @@ func main() {
 			}
 		}
 
-		var fileType string
-		if !*fileType {
-			fileType = "SQL"
-		}
-
-		var objectName string = time.Now().Format(time.RFC3339Nano) + "." + strings.ToLower(fileType)
+		var objectName string = time.Now().Format(time.RFC3339Nano) + "." + strings.ToLower(*fileType)
 
 		if *compression {
 			objectName = objectName + ".gz"
 		}
 
-		err := cloudsql.ExportCloudSQLDatabase(ctx, sqlAdminSvc, databases, *project, string(instance), *bucket, objectName, strings.ToUpper(fileType))
+		err := cloudsql.ExportCloudSQLDatabase(ctx, sqlAdminSvc, databases, *project, string(instance), *bucket, objectName, strings.ToUpper(*fileType))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/cloudsql/cloudsql.go
+++ b/pkg/cloudsql/cloudsql.go
@@ -117,13 +117,13 @@ func ListDatabasesForCloudSQLInstance(ctx context.Context, sqlAdminSvc *sqladmin
 }
 
 // ExportCloudSQLDatabase exports a Cloud SQL database to a Google Cloud Storage bucket.
-func ExportCloudSQLDatabase(ctx context.Context, sqlAdminSvc *sqladmin.Service, databases []string, projectID, instanceID, bucketName, objectName string) error {
+func ExportCloudSQLDatabase(ctx context.Context, sqlAdminSvc *sqladmin.Service, databases []string, projectID, instanceID, bucketName, objectName string, fileType string) error {
 	for _, database := range databases {
 		log.Printf("Exporting database %s for instance %s", database, instanceID)
 
 		req := &sqladmin.InstancesExportRequest{
 			ExportContext: &sqladmin.ExportContext{
-				FileType:  "SQL",
+				FileType:  fileType,
 				Kind:      "sql#exportContext",
 				Databases: []string{database},
 				Uri:       fmt.Sprintf("gs://%s/%s/%s/%s/%s", bucketName, projectID, instanceID, database, objectName),


### PR DESCRIPTION
Hi,
I've add the fileType option because my cloud sql instance is a SQL Server and I cannot export databases in SQL Format.
I've added the default for the option for retrocompatibilty.